### PR TITLE
Task 7

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,9 +7,19 @@ import { connectRouter } from './plugins/vue-router';
 import { connecti18n } from './plugins/vue-i18n';
 
 import store from './store/store';
+import axios from 'axios';
 
 const createApp = () => {
 	Vue.config.productionTip = false;
+
+	axios.interceptors.response.use(
+		response => response,
+		error => {
+			if ([401, 403].includes(error?.response?.status)) {
+				alert('Please authorize in the application!');
+			}
+		}
+	);
 
 	return new Vue({
 		el: '#app',

--- a/src/views/ProductImport/ui/CSVFileUploader.vue
+++ b/src/views/ProductImport/ui/CSVFileUploader.vue
@@ -52,6 +52,9 @@ import axios from 'axios';
 const fetchPresignedS3Url = (url: string, fileName: string) => {
 	return axios({
 		method: 'GET',
+		headers: {
+			Authorization: `Basic ${localStorage.getItem('authorization_token')}`,
+		},
 		url,
 		params: {
 			name: encodeURIComponent(fileName),


### PR DESCRIPTION
**Changes from task 7:**

- Client application is updated to send "Authorization: Basic authorization_token" header on import. Client should get authorization_token value from browser [localStorage](https://developer.mozilla.org/ru/docs/Web/API/Window/localStorage)
- +1 - Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior should be added to the nodejs-aws-fe-main/src/index.tsx file.